### PR TITLE
fix: Pin `buildkite/puppeteer` to tag `5.2.1`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildkite/puppeteer
+FROM buildkite/puppeteer:5.2.1
 # FROM node:12.18.3-buster-slim@sha256:dd6aa3ed10af4374b88f8a6624aeee7522772bb08e8dd5e917ff729d1d3c3a4f
 
 # # source https://github.com/buildkite/docker-puppeteer/blob/master/Dockerfile


### PR DESCRIPTION
The latest tag breaks our builds with a libXss error (https://github.com/buildkite/docker-puppeteer/pull/141)