### PR TITLE
feat: build/publish docker image workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Build and publish docker image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: build and publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Registry login
+      run: |
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
+    - name: Build docker image
+      run: |
+        docker pull ghcr.io/${{ github.repository }}:latest || true
+        docker build . \
+          --cache-from ghcr.io/${{ github.repository }}:latest \
+          -t ghcr.io/${{ github.repository }}:latest \
+          -t ghcr.io/${{ github.repository }}:$GITHUB_SHA
+
+    - name: Publish docker image
+      run: |
+        docker push ghcr.io/${{ github.repository }}:$GITHUB_SHA
+        docker push ghcr.io/${{ github.repository }}:latest

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'jest-visual-snapshop'
+name: 'action-html-to-image'
 description: 'Renders images from HTML'
 author: 'Sentry'
 inputs:
@@ -8,4 +8,4 @@ inputs:
     description: 'path to custom css to inject'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/getsentry/action-html-to-image:latest'


### PR DESCRIPTION
Add a workflow to build docker image and publish to GitHub's Container Registry and change the Action to use said image. Otherwise, workflows that use this Action will need to re-build the image every-time. This roughly took 60-70 seconds. With these changes, workflows will only need to pull down the docker image which takes roughly 30 seconds.

