### PR TITLE
ref: purge yarn cache to save ~210MB on the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ FROM buildkite/puppeteer:10.0.0
 
 COPY . .
 
-RUN yarn install --production
-RUN yarn tsc --version
-RUN yarn build
+RUN : \
+    && yarn install --production \
+    && yarn build \
+    && yarn cache clean
 
 ENTRYPOINT ["node", "/lib/main.js"]


### PR DESCRIPTION
size difference:

```console
$ podman images | grep -E '(wat|getsentry)'
localhost/wat                           latest      e28e23113c30  6 minutes ago  1.71 GB
ghcr.io/getsentry/action-html-to-image  latest      bc369995a254  11 months ago  1.92 GB
```

I noticed that the base image is unmaintained so I'll probably take a second pass to inline the useful parts from that into this

validated here: https://github.com/getsentry/sentry/pull/36256